### PR TITLE
Default queue name to request URL if not provided

### DIFF
--- a/ajaxq.js
+++ b/ajaxq.js
@@ -11,7 +11,8 @@
     $.ajaxq = function(qname, opts) {
 
         if (typeof opts === "undefined") {
-            throw ("AjaxQ: queue name is not provided");
+            opts = qname;
+            qname = opts.url;
         }
 
         // Will return a Deferred promise object extended with success/error/callback, so that this function matches the interface of $.ajax


### PR DESCRIPTION
This is a great plugin. I've used it on a number of projects and noticed that in all but one case I used the request URL as the queue name. To me, this seems like a reasonable default for scoping requests.

This simple patch does just that. If no queue name is provided, it uses the request URL. Now adding support for queued requests is as simple as including the library and changing calls from `$.ajax` to `$.ajaxq`.
