### PR TITLE
Add the ability to check if any single queue isn't empty.

### DIFF
--- a/ajaxq.js
+++ b/ajaxq.js
@@ -87,11 +87,11 @@
         };
     });
 
-    isQueueRunning = function(qname) {
+    var isQueueRunning = function(qname) {
         return queues.hasOwnProperty(qname);
     }
 
-    isAnyQueueRunning = function() {
+    var isAnyQueueRunning = function() {
         for (var i in queues) {
             if (checkIfQueueRunning(i)) return true;
         }


### PR DESCRIPTION
Hello,

AjaxQ has been great for my projects. Thank you very much for writing it.

One of the projects I'm working on utilizes a number of different queues to extract some parallelism out of the program execution while still sending requests in order where necessary. Unfortunately this meant that I ran up against the problem of not having the ability to check if a given queue is still running. I added this in order to serve my project, but it also might be useful for others. Perhaps you'd consider merging it? Of course, I'm open to any suggestions regarding the API...
