### PR TITLE
Small error in axaq.clear() comm

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
     $.getq ("MyQueue", 'path/to/another/resource', onsuccess);
     $.getq ("MyQueue", 'path/to/another/resource', onsuccess);
     
-    // Will cancel the current request and clear future ones.
+    // Will clear future requests without cancelling the current one
     $.ajaxq.clear("MyQueue"); 
 </pre>
 


### PR DESCRIPTION
The heading comment on clear() says: "//Clears queued requests in the given queue, without cancelling the current request", but then on the actual invocation (line 220) says "//Will cancel the current request and clear future ones". It seems copy&paste from abort().
I understants that clear() only empties the queue and does not touch the current request.
