### PR TITLE
Add tests for ajaxq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -1,0 +1,3 @@
+{
+  "generator-mocha": {}
+}

--- a/bower.json
+++ b/bower.json
@@ -22,5 +22,10 @@
   ],
   "dependencies": {
     "jquery": ">1.6"
+  },
+  "devDependencies": {
+    "chai": "~3.3.0",
+    "mocha": "~2.3.3",
+    "sinon-1.17.0": "http://sinonjs.org/releases/sinon-1.17.0.js"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
   "ignore": [
     "**/.*",
     "bower_components",
+    "test",
     "demo",
     "index.html"
   ],

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mocha Spec Runner</title>
+  <link rel="stylesheet" href="../bower_components/mocha/mocha.css">
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+  <script src="../ajaxq.js"></script>
+  <script src="../bower_components/mocha/mocha.js"></script>
+  <script>mocha.setup('bdd');</script>
+  <script src="../bower_components/sinon-1.17.0/index.js"></script>
+  <script src="../bower_components/chai/chai.js"></script>
+  <script>
+    var assert = chai.assert;
+    var expect = chai.expect;
+    var should = chai.should();
+  </script>
+  <!-- bower:js -->
+  <!-- endbower -->
+  <!-- include source files here... -->
+  <!-- include spec files here... -->
+  <script src="spec/test.js"></script>
+  <script>
+    if (navigator.userAgent.indexOf('PhantomJS') === -1) {
+      mocha.run();
+    }
+  </script>
+</body>
+</html>

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -1,0 +1,163 @@
+(function () {
+  'use strict';
+
+  describe('AjaxQ', function () {
+    beforeEach(function() {
+        this.xhr = sinon.useFakeXMLHttpRequest();
+
+        this.requests = [];
+        this.xhr.onCreate = function(xhr) {
+            this.requests.push(xhr);
+        }.bind(this);
+    });
+
+    afterEach(function() {
+        this.xhr.restore();
+    });
+
+    describe('High level functions', function () {
+
+      it('$.ajaxq', function (done) {
+        var resp = {
+          id: 1
+        };
+        $.ajaxq ('test-queue', {
+            url: 'http://example.com',
+            type: 'post'
+        }).then(function (data) {
+          expect(data).to.be.deep.equal(resp);
+          done();
+        });
+        this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                 JSON.stringify(resp));
+      });
+
+      it('$.getq should return promise', function (done) {
+        var resp = {
+          id: 1
+        };
+        $.getq ('test-queue', 'http://example.com')
+        .then(function (data) {
+          expect(data).to.be.deep.equal(resp);
+          done();
+        });
+        this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                 JSON.stringify(resp));
+      });
+
+      it('$.getq should call callback', function (done) {
+        var resp = {
+          id: 1
+        };
+        $.getq ('test-queue', 'http://example.com', function (data) {
+                  expect(data).to.be.deep.equal(resp);
+                  done();
+               })
+        this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                 JSON.stringify(resp));
+      });
+
+      it('$.postq should return promise', function (done) {
+        var resp = {
+          id: 1
+        };
+        $.postq ('test-queue','http://example.com')
+        .then(function (data) {
+          expect(data).to.be.deep.equal(resp);
+          done();
+        });
+        this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                 JSON.stringify(resp));
+      });
+
+      it('$.postq should call callback', function (done) {
+        var resp = {
+          id: 1
+        };
+        $.postq ('test-queue','http://example.com', function (data) {
+          expect(data).to.be.deep.equal(resp);
+          done();
+        });
+        this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                 JSON.stringify(resp));
+      });
+    });
+
+    describe('Test low level methods', function () {
+      describe('$.ajaxq.isRunning', function () {
+        it('should return true if any request running', function () {
+          var resp = {
+            id: 1
+          };
+          $.ajaxq ('test-queue',{
+                   url: 'http://example.com',
+                   type: 'post'
+          });
+          expect($.ajaxq.isRunning()).to.be.Ok;
+          expect($.ajaxq.isRunning('test-queue')).to.be.Ok;
+          this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                   JSON.stringify(resp));
+        });
+
+        it('should return false if no request running', function (done) {
+          var resp = {
+            id: 1
+          };
+          $.ajaxq ('test-queue',{
+                   url: 'http://example.com',
+                   type: 'post'
+          })
+          .then(function () {
+            expect($.ajaxq.isRunning()).to.be.not.Ok;
+            done();
+          });
+          this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                   JSON.stringify(resp));
+        });
+
+        it('should return false if queue is not added', function () {
+          expect($.ajaxq.isRunning('test-nonexistent-queue')).to.be.not.Ok;
+        });
+      });
+
+      describe('$.ajax.getActiveRequest', function () {
+        it('should throw error is no queue is defined', function () {
+          expect($.ajaxq.abort).to.throw('AjaxQ: queue name is required');
+        });
+
+        it('should get active request', function (done) {
+          var resp = {
+            id: 1
+          };
+          $.ajaxq ('test-queue',{
+                   url: 'http://example.com',
+                   type: 'post'
+          })
+          .then(function () {
+            done();
+          });
+          var xhr = $.ajaxq.getActiveRequest('test-queue');
+          this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                   JSON.stringify(resp));
+          expect(xhr.status).to.be.equal(200);
+        });
+      });
+
+      describe('$.ajaxq.abort', function () {
+        it('should throw error is no queue is defined', function () {
+          expect($.ajaxq.abort).to.throw('AjaxQ: queue name is required');
+        });
+
+        xit('should resolve promise upon queue abort', function () {
+
+        });
+      });
+
+      describe('$.ajaxq.clear', function () {
+        xit('should resolve promise upon queue cleared', function () {
+
+        });
+      });
+    });
+  });
+})();


### PR DESCRIPTION
This PR is to add tests for ajaxq

Installed via yeoman generator-mocha https://github.com/yeoman/generator-mocha

1. devDependencies
1.1 Test framework - Mocha
1.2 Assertion library - Chai
1.3 Stub library - Sinon

2. Changed to existing files.
2.1 bower.json
2.1.1 devDependencies for testing is added
2.1.2 test folder is added to bower.json ignore

3. New files
3.1 .gitignore - to ignore bower_components folder
3.2 .yo-rc.json - yeoman generator config file (auto generated by yeoman)
3.3 test/index.html - entry file to run tests in browser
3.4 test/spec/test.js - test specs for ajaxq

-------------------------------------

For functions `$.ajaxq.abort()` and `$.ajaxq.clean()`, tests are not complete as these functions does not have return value. 
Suggestion would be to return a `$.Deferred()` promise object when this functions are called and resolve it once the functions complete processing.