### PR TITLE
Use https on https://jsfiddle.net echo calls to prevent cross protocol issues

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -56,7 +56,7 @@ function addRequest(name, delay, container, num, error) {
 
 
     var jqXHR = $.ajaxq (name, {
-        url: 'http://jsfiddle.net/echo/jsonp/',
+        url: 'https://jsfiddle.net/echo/jsonp/',
         type: 'post',
         dataType: error ? "" : "jsonp",
         data: {


### PR DESCRIPTION
At the moment your demo is broken as your site is on https and your ajax calls are to http://jsfiddle.net/echo/jsonp/ which is on http.

This PR ensures you call over https

![screen shot 2016-10-14 at 20 16 59](https://cloud.githubusercontent.com/assets/400092/19399807/3216b2b2-924b-11e6-96f2-513f44a7c3a9.png)
